### PR TITLE
A stylistic adjustment to the border-radius on the Wunderlist theme

### DIFF
--- a/css/themes/wunderlist.css
+++ b/css/themes/wunderlist.css
@@ -260,8 +260,14 @@ body {
       background: -o-linear-gradient(top, #ffffff 0%, #f9f9f9 100%);
       background: -ms-linear-gradient(top, #ffffff 0%, #f9f9f9 100%);
       background: linear-gradient(top, #ffffff 0%, #f9f9f9 100%);
-      border-radius: 5px;
+      border-radius: 0;
       box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.5); }
+    #content #tasks ul li:first-of-type {
+      border-radius:5px 5px 0 0; }
+    #content #tasks ul li:last-of-type {
+      border-radius:0 0 5px 5px; }
+    #content #tasks ul li:only-of-type {
+      border-radius:5px; }
       #content #tasks ul li .todotxt {
         height: 30px;
         padding: 0 10px 0 0;


### PR DESCRIPTION
I made some adjustments to the way the border-radius property is applied to the list of tasks on the Wunderlist theme. In my opinion it is much more pleasant to see the list of tasks this way.

The original theme for reference:
http://i.imgur.com/eE2qv.png

The theme with the changed border-radius:
http://i.imgur.com/r3UeT.png

The case with two tasks:
http://i.imgur.com/MhRue.png

And one task:
http://i.imgur.com/P6rAt.png
