### PR TITLE
Fixed missing arrows on the calendar widget

### DIFF
--- a/css/jquery-ui-1.8.16.custom.css
+++ b/css/jquery-ui-1.8.16.custom.css
@@ -97,11 +97,14 @@
 /* Icons
 ----------------------------------*/
 /* states and images */
-.ui-icon { width: 16px; height: 16px; }
+.ui-icon { width: 16px; height: 16px; background-image: url(images/glyphicons-halflings.png); }
 
-.ui-icon.glyph-icon-arrow-left { width: 16px; height: 16px; background-image: url(images/glyphicons-halflings.png); background-position: -240px -96px; cursor: pointer; }
+.ui-icon.glyph-icon-arrow-left { width: 16px; height: 16px; background-position: -240px -96px; cursor: pointer; }
 
-.ui-icon.glyph-icon-arrow-right { width: 16px; height: 16px; background-image: url(images/glyphicons-halflings.png); background-position: -264px -96px; cursor: pointer; }
+.ui-icon.glyph-icon-arrow-right { width: 16px; height: 16px; background-position: -264px -96px; cursor: pointer; }
+
+.ui-icon-circle-triangle-e { background-position: -456px -72px; }
+.ui-icon-circle-triangle-w { background-position: -432px -72px; }
 
 /* Misc visuals
 ----------------------------------*/

--- a/css/screen.css
+++ b/css/screen.css
@@ -443,11 +443,14 @@ button.s1.no:hover { background: -webkit-gradient(linear, 50% 0%, 50% 100%, colo
 /* Icons
 ----------------------------------*/
 /* states and images */
-.ui-icon { width: 16px; height: 16px; }
+.ui-icon { width: 16px; height: 16px; background-image: url(images/glyphicons-halflings.png); }
 
-.ui-icon.glyph-icon-arrow-left { width: 16px; height: 16px; background-image: url(images/glyphicons-halflings.png); background-position: -240px -96px; cursor: pointer; }
+.ui-icon.glyph-icon-arrow-left { width: 16px; height: 16px; background-position: -240px -96px; cursor: pointer; }
 
-.ui-icon.glyph-icon-arrow-right { width: 16px; height: 16px; background-image: url(images/glyphicons-halflings.png); background-position: -264px -96px; cursor: pointer; }
+.ui-icon.glyph-icon-arrow-right { width: 16px; height: 16px; background-position: -264px -96px; cursor: pointer; }
+
+.ui-icon-circle-triangle-e { background-position: -456px -72px; }
+.ui-icon-circle-triangle-w { background-position: -432px -72px; }
 
 /* Misc visuals
 ----------------------------------*/

--- a/sass/jquery-ui-1.8.16.custom.scss
+++ b/sass/jquery-ui-1.8.16.custom.scss
@@ -202,19 +202,20 @@
 ----------------------------------*/
 
 /* states and images */
-.ui-icon { width: 16px; height: 16px; }
+.ui-icon { width: 16px; height: 16px; background-image: url(images/glyphicons-halflings.png); }
 
 .ui-icon.glyph-icon-arrow-left {
-  width: 16px; height: 16px; background-image: url(images/glyphicons-halflings.png);
+  width: 16px; height: 16px;
   background-position: -240px -96px;
   cursor: pointer;
 }
 .ui-icon.glyph-icon-arrow-right {
-  width: 16px; height: 16px; background-image: url(images/glyphicons-halflings.png);
+  width: 16px; height: 16px;
   background-position: -264px -96px;
   cursor: pointer;
 }
-
+.ui-icon-circle-triangle-e { background-position: -456px -72px; }
+.ui-icon-circle-triangle-w { background-position: -432px -72px; }
 
 /* Misc visuals
 ----------------------------------*/


### PR DESCRIPTION
The calendar for setting a task due date is currently missing the forward and back buttons. I tried to fix this in a way that will use the Glyph Icon set already included in the project.  My changes shouldn't break the existing `.glyph-icon-arrow-*` styles, but I couldn't test this because I couldn't figure out if/where those classes are used in the project.

tl;dr: This commit adds missing arrows to the calendar and it shouldn't break anything.
