### PR TITLE
Don't depend on datepicker widget for setting date (Fixes 134)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -830,8 +830,8 @@ $tasks.on('expand', 'li', function() {
 
 	$this.find('.date')
 		.datepicker({weekStart: core.storage.prefs.weekStartsOn})
-		.on('changeDate', function(ev) {
-			core.storage.tasks[id].date = ev.date.valueOf()
+		.on('change', function() {
+			core.storage.tasks[id].date = Date.parse($(this).val())
 			ui.lists.update().count()
 			core.storage.save([['tasks', id, 'date']])
 		})


### PR DESCRIPTION
This change allows the date to be set by typing directly into `input.date`. Without this change, the date can only be set by using the datepicker -- see issue #134 for more details.

Since we could no longer use `ev.date.valueOf()` in the `onchange` function, this reads the text directly from the `input` and uses `Date.parse()` to convert it to a date.
