### PR TITLE
Sort files before compiling plugins.js

### DIFF
--- a/js/compile.rb
+++ b/js/compile.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # This is a fucking awesome script to compile scripts. Remeber to run from the js dir.
 #File Listing
-filelist = Dir["./plugins/*.js"]
+filelist = Dir["./plugins/*.js"].entries.sort
 compiledscript = ""
 filelist.each { |x|
 	compiledscript += "/* " + x + " */\n\n" + IO.read(x) + "\n"


### PR DESCRIPTION
When compiling `plugins.js` on Windows and Ubuntu, the individual plugins were being added in a different order than when I compiled on Mac. Hopefully this change to the Ruby script will ensure a more consistent order across platforms.

I should mention that my Ruby experience consists mostly of "Hello World" examples, so only merge this change if it looks like it makes sense. :)
