### PR TITLE
Hide logged tasks from searches

### DIFF
--- a/css/metro.css
+++ b/css/metro.css
@@ -47,7 +47,7 @@ html, button, input, select, textarea { font-family: "Segoe UI", "Open Sans", sa
 #tasks .panel .right button.settingsbtn { background: url("themes/metro/settings.png") no-repeat 0 0; width: 24px; }
 #tasks .panel .right input { background: white url("themes/metro/search.png") no-repeat right center; background-color: rgba(255, 255, 255, 0.9); border: 0; margin: 0 0 0 4px; padding-right: 25px; -webkit-transition: 200ms ease width; width: 140px; }
 #tasks .panel .right input:focus { border: 0; outline: 0; width: 250px; }
-#tasks .tasksContent { text-align: left; }
+#tasks .tasksContent { font-size: 15px; text-align: left; }
 #tasks .tasksContent h2 { display: inline-block; font-size: 25px; font-weight: normal; line-height: 25px; margin: 0; padding: 16px 20px 8px 16px; text-transform: capitalize; }
 #tasks .tasksContent .button { border: 0; border-radius: 0; }
 #tasks .tasksContent .button#updateLogbook { color: #fff; float: right; margin: 16px 20px; background: #8866bb; border: 1px solid #7a54b3; }
@@ -76,7 +76,7 @@ html, button, input, select, textarea { font-family: "Segoe UI", "Open Sans", sa
 #tasks .tasksContent ul li .checkbox.low:before { background: #00aadd; }
 #tasks .tasksContent ul li .checkbox.medium:before { background: #ffbb44; }
 #tasks .tasksContent ul li .checkbox.high:before { background: #ee3333; }
-#tasks .tasksContent ul li .content { font-size: 15px; padding: 0 10px 0 0; }
+#tasks .tasksContent ul li .content { padding: 0 10px 0 0; }
 #tasks .tasksContent ul li .notes { background: url("themes/metro/note.png") no-repeat; height: 16px; margin-top: 8px; width: 16px; }
 #tasks .tasksContent ul li .tag { color: #999; cursor: pointer; font-style: italic; margin: 0 6px; padding: 0; }
 #tasks .tasksContent ul li .tag:before { content: "#"; }

--- a/css/style.css
+++ b/css/style.css
@@ -118,7 +118,7 @@ html, button, input, select, textarea { font-family: "Helvetica", "Arial", "Ubun
 #sidebar h2 { margin: 0; padding: 0 0 0 15px; font-size: 13px; line-height: 30px; height: 30px; text-transform: uppercase; border-top: 1px solid #000; border-bottom: 1px solid #000; }
 #sidebar h2 button { background: transparent; float: right; border-top: 1px solid transparent; border-bottom: 1px solid transparent; border-left: 0; border-right: 0; padding: 0; font-weight: bold; }
 #sidebar h2 .list-toggle { display: inline-block; cursor: pointer; float: right; height: 30px; width: 40px; }
-#sidebar h2 .list-toggle .icon { cursor: pointer; margin: 11px 0 0 11px; width: 0; height: 0; border-right: 8px solid #ccc; border-top: 5px solid transparent; border-bottom: 5px solid transparent; -webkit-transform: rotate(270deg); -moz-transform: rotate(270deg); -ms-transform: rotate(270deg); -o-transform: rotate(270deg); transform: rotate(270deg); -webkit-transition: 100ms all ease; -moz-transition: 100ms all ease; -ms-transition: 100ms all ease; -o-transition: 100ms all ease; transition: 100ms all ease; }
+#sidebar h2 .list-toggle .icon { cursor: pointer; margin: 11px 0 0 11px; width: 0; height: 0; border-right: 8px solid #ccc; border-top: 5px solid transparent; border-bottom: 5px solid transparent; -webkit-transform: rotate(270deg); -moz-transform: rotate(270deg); -ms-transform: rotate(270deg); -o-transform: rotate(270deg); transform: rotate(270deg); -webkit-transition: 100ms all ease; -moz-transition: 100ms all ease; -o-transition: 100ms all ease; transition: 100ms all ease; }
 #sidebar h2 .list-toggle:hover .icon { border-right-color: #5b5b5b; }
 #sidebar h2 .list-toggle.collapsed .icon { -webkit-transform: rotate(180deg); -moz-transform: rotate(180deg); -ms-transform: rotate(180deg); -o-transform: rotate(180deg); transform: rotate(180deg); }
 #sidebar h2.collapsed { border-bottom: none; }
@@ -126,11 +126,11 @@ html, button, input, select, textarea { font-family: "Helvetica", "Arial", "Ubun
 #sidebar #lists li:hover .edit, #sidebar #lists li:hover .delete { display: inline-block; }
 #sidebar ul { margin: 0; padding: 0; }
 #sidebar ul * { cursor: pointer; }
-#sidebar ul li { display: -webkit-box; display: -moz-box; display: -ms-box; display: box; height: 30px; -moz-box-sizing: border-box; box-sizing: border-box; line-height: 30px; font-weight: normal; font-size: 13px; color: #444444; padding: 0 0 0 15px; position: relative; -webkit-transition: 150ms background ease, 150ms color ease; -moz-transition: 150ms background ease, 150ms color ease; -ms-transition: 150ms background ease, 150ms color ease; -o-transition: 150ms background ease, 150ms color ease; transition: 150ms background ease, 150ms color ease; width: 100% !important; }
+#sidebar ul li { display: -webkit-box; display: -moz-box; display: -ms-box; display: box; height: 30px; -moz-box-sizing: border-box; box-sizing: border-box; line-height: 30px; font-weight: normal; font-size: 13px; color: #444444; padding: 0 0 0 15px; position: relative; -webkit-transition: 150ms background ease, 150ms color ease; -moz-transition: 150ms background ease, 150ms color ease; -o-transition: 150ms background ease, 150ms color ease; transition: 150ms background ease, 150ms color ease; width: 100% !important; }
 #sidebar ul li .edit { background: url("img/list_edit.png") 0 -105px; }
 #sidebar ul li .edit.open { padding: 0 7px 0 6px; background-position: 0 177px; }
 #sidebar ul li .delete { background: url("img/list_edit.png") 1px -83px; }
-#sidebar ul li .edit, #sidebar ul li .delete { border: 0; height: 16px; margin-top: 7px; margin-right: 5px; opacity: 0.5; padding: 0 7px; -webkit-transition: opacity 0.15s; -moz-transition: opacity 0.15s; -ms-transition: opacity 0.15s; -o-transition: opacity 0.15s; transition: opacity 0.15s; }
+#sidebar ul li .edit, #sidebar ul li .delete { border: 0; height: 16px; margin-top: 7px; margin-right: 5px; opacity: 0.5; padding: 0 7px; -webkit-transition: opacity 0.15s; -moz-transition: opacity 0.15s; -o-transition: opacity 0.15s; transition: opacity 0.15s; }
 #sidebar ul li .edit:hover, #sidebar ul li .delete:hover { opacity: 1; }
 #sidebar ul li .count { display: inline-block; text-align: center; padding: 1px 9px; line-height: 28px; margin: 0 10px 0 0; min-width: 13px; }
 #sidebar ul li .name { display: block; -webkit-box-flex: 1; -moz-box-flex: 1; -ms-box-flex: 1; box-flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -148,16 +148,14 @@ html, button, input, select, textarea { font-family: "Helvetica", "Arial", "Ubun
 .panel .left { float: left; margin-left: -16px; font-size: 0; }
 .panel .left span { position: relative; color: #000; }
 .panel .left span ul { display: none; position: absolute; left: 0; margin: 1px 0; padding: 0; background: #fff; }
-.panel .left span ul li { list-style-type: none; padding: 0 8px; width: 120px; cursor: pointer; font-size: 13px; line-height: 28px; }
+.panel .left span ul li { list-style-type: none; padding: 0 10px; width: 69px; cursor: pointer; font-size: 13px; line-height: 25px; }
 .panel .left span ul li:hover { background: rgba(0, 0, 0, 0.2); }
 .panel .left span ul li.current { box-shadow: inset 0 0 35px rgba(0, 0, 0, 0.5); background: rgba(0, 0, 0, 0.2); }
-.panel .left span ul li .icon { display: inline-block; background: url("img/sort_menu.png"); margin-right: 8px; width: 12px; height: 12px; }
-.panel .left span ul li .icon.date { background-position: 0 0; }
-.panel .left span ul li .icon.hand { background-position: 0 -12px; }
-.panel .left span ul li .icon.magic { background-position: -12px 0; }
-.panel .left span ul li .icon.priority { background-position: -12px -12px; }
-.panel .left span ul li .icon.title { background-position: 0 -24px; }
-
+.panel .left span ul li .icon { display: inline-block; background: url("img/sort_menu.png"); margin-right: 5px; }
+.panel .left span ul li .icon.date { background-position: 0 0; width: 11px; height: 12px; }
+.panel .left span ul li .icon.hand { background-position: 0 -12px; width: 12px; height: 11px; }
+.panel .left span ul li .icon.magic { background-position: -12px 0; width: 13px; height: 12px; }
+.panel .left span ul li .icon.priority { background-position: -12px -12px; width: 13px; height: 11px; }
 .panel .left span.open ul { display: block; }
 .panel .right { float: right; }
 .panel .right button { height: 40px; }
@@ -170,13 +168,13 @@ html, button, input, select, textarea { font-family: "Helvetica", "Arial", "Ubun
 #tasks { position: absolute; top: 0; bottom: 0; right: 0; left: 0; height: 100%; z-index: 1; -moz-box-sizing: border-box; box-sizing: border-box; background-image: #ffffff; background-image: -webkit-radial-gradient(50% 50%, ellipse closest-side, rgba(255, 255, 255, 0.4) 0%, rgba(255, 255, 255, 0) 100%); background-image: -moz-radial-gradient(50% 50%, ellipse closest-side, rgba(255, 255, 255, 0.4) 0%, rgba(255, 255, 255, 0) 100%); background-position: center center; background-repeat: repeat; background-size: cover; }
 #tasks .tile { background-size: auto; }
 #tasks .shrink { background-size: contain; }
-#tasks .tasksContent { overflow-y: auto; text-align: center; }
+#tasks .tasksContent { font-size: 13px; overflow-y: auto; text-align: center; }
 #tasks .tasksContent h2 { text-align: center; font-size: 20px; }
 #tasks .tasksContent .button { cursor: pointer; margin: 0 0 15px; padding: 6px 15px; border-radius: 4px; background: rgba(255, 255, 255, 0.7); border: 1px solid #bbb; font-size: 14px; font-weight: bold; color: #444; }
 #tasks .tasksContent .button:hover { background: rgba(255, 255, 255, 0.6); }
 #tasks .tasksContent ul { padding: 0 20px 40px 16px; margin: 0; text-align: left; }
-#tasks .tasksContent ul:last-child { padding-bottom: 20px; }
-#tasks .tasksContent ul li { display: block; min-height: 30px; height: 30px; cursor: pointer; overflow: hidden; padding: 0; position: relative; z-index: 2; margin-bottom: -1px; background: #fff; border: 1px solid #000; font-size: 13px; line-height: 30px; color: #111; -webkit-transform: translateZ(0); -webkit-transition-property: margin, opacity; -webkit-transition-duration: 150ms, 300ms; -webkit-transition-timing-function: ease, ease; -moz-transform: translateZ(0); -moz-transition-property: margin, opacity; -moz-transition-duration: 150ms, 300ms; -moz-transition-timing-function: ease, ease; }
+#tasks .tasksContent ul:last-of-type { padding-bottom: 20px; }
+#tasks .tasksContent ul li { display: block; min-height: 30px; height: 30px; cursor: pointer; overflow: hidden; padding: 0; position: relative; z-index: 2; margin-bottom: -1px; background: #fff; border: 1px solid #000; line-height: 30px; color: #111; -webkit-transform: translateZ(0); -webkit-transition-property: margin, opacity; -webkit-transition-duration: 150ms, 300ms; -webkit-transition-timing-function: ease, ease; -moz-transform: translateZ(0); -moz-transition-property: margin, opacity; -moz-transition-duration: 150ms, 300ms; -moz-transition-timing-function: ease, ease; }
 #tasks .tasksContent ul li.animate.height { -webkit-transition-property: margin, opacity, height; -webkit-transition-duration: 150ms, 300ms, 150ms; -webkit-transition-timing-function: ease, ease, ease; -moz-transition-property: margin, opacity, height; -moz-transition-duration: 150ms, 300ms, 150ms; -moz-transition-timing-function: ease, ease, ease; }
 #tasks .tasksContent ul li.placeholder { background: rgba(0, 0, 0, 0.1); box-shadow: 0 0 0 #000; }
 #tasks .tasksContent ul li .boxhelp { display: -webkit-box; display: -moz-box; display: -ms-box; display: box; width: 100%; }
@@ -200,13 +198,15 @@ html, button, input, select, textarea { font-family: "Helvetica", "Arial", "Ubun
 #tasks .tasksContent ul li input.date { text-align: center; }
 #tasks .tasksContent ul li input.date, #tasks .tasksContent ul li input.tags { border-left: 1px solid #000; padding: 8px 5px; vertical-align: top; width: 80px; }
 #tasks .tasksContent ul li input.date:focus, #tasks .tasksContent ul li input.tags:focus { outline: 0; height: 31px; }
-#tasks .tasksContent ul li input.tags { -webkit-transition: width 0.15s; -moz-transition: width 0.15s; -ms-transition: width 0.15s; -o-transition: width 0.15s; transition: width 0.15s; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 59px; }
+#tasks .tasksContent ul li input.tags { -webkit-transition: width 0.15s; -moz-transition: width 0.15s; -o-transition: width 0.15s; transition: width 0.15s; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 59px; }
 #tasks .tasksContent ul li input.tags:focus, #tasks .tasksContent ul li input.tags.hasContent { width: 250px; }
 #tasks .tasksContent ul li.expanded { opacity: 1; }
 #tasks .tasksContent ul li.selected.expanded { background: #fff; }
 #tasks .tasksContent ul li .hidden { display: none; }
 #tasks .tasksContent ul li .hidden textarea { width: 100%; border: 0; border-top: 1px solid #000; -moz-box-sizing: border-box; box-sizing: border-box; padding: 8px 30px 8px 32px; resize: none; min-height: 20px; overflow: hidden; }
 #tasks .tasksContent ul li .hidden textarea:focus { box-shadow: none; outline: 0; }
+#tasks .tasksContent .showMore { color: #555; margin-left: 16px; }
+#tasks .tasksContent .showMore:hover { text-decoration: underline; }
 
 .vsplitbar { border-right: 4px solid transparent; -moz-box-sizing: border-box; box-sizing: border-box; position: absolute; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; -webkit-user-select: none; width: 5px; border-left: 1px solid #000; box-shadow: 0 -1px 0 #111111, 0 -41px 0 white; top: 41px; height: 100%; z-index: 2; }
 
@@ -240,7 +240,7 @@ html, button, input, select, textarea { font-family: "Helvetica", "Arial", "Ubun
 #prefsDialog { -webkit-animation: settingsanim 250ms 1; -webkit-animation-timing-function: ease-out; display: none; position: fixed; width: 520px; left: 50%; margin-left: -250px; top: 100px; background: #fff; box-shadow: 0 2px 15px rgba(0, 0, 0, 0.7); z-index: 100; border-radius: 2px; }
 #prefsDialog > ul { height: 30px; margin: 0; padding: 0; border-top-left-radius: 2px; border-top-right-radius: 2px; border-bottom: 1px solid rgba(0, 0, 0, 0.2); background: #ddd; }
 #prefsDialog > ul > li { display: inline-block; margin: 0; width: 20%; box-sizing: border-box; -webkit-box-sizing: border-box; -moz-box-sizing: border-box; text-align: center; line-height: 30px; height: 30px; }
-#prefsDialog > ul > li.active { -webkit-transition: 150ms background ease; -moz-transition: 150ms background ease; -ms-transition: 150ms background ease; -o-transition: 150ms background ease; transition: 150ms background ease; background: #f0f0f0; }
+#prefsDialog > ul > li.active { -webkit-transition: 150ms background ease; -moz-transition: 150ms background ease; -o-transition: 150ms background ease; transition: 150ms background ease; background: #f0f0f0; }
 #prefsDialog > ul > li.active a { color: #222; }
 #prefsDialog > ul > li:first-child { border-top-left-radius: 5px; }
 #prefsDialog > ul > li:last-child { border-top-right-radius: 5px; }

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -1829,6 +1829,7 @@ plugin.add(function() {
 			// Set vars
 			var query = input.split(' '),
 				results = [],
+				loggedResults = [],
 				search;
 
 			if (ui.session.selected == 'all') {
@@ -1841,7 +1842,11 @@ plugin.add(function() {
 						// Search Task
 						var str = searcher(t)
 						if (str) {
-							results.push(str)
+							if (core.storage.tasks[t].list === 'logbook') {
+								loggedResults.push(str)
+							} else {
+								results.push(str)
+							}
 						}
 
 					}
@@ -1856,6 +1861,20 @@ plugin.add(function() {
 			}
 			// Draws
 			$tasks.find('ul').append(ui.lists.drawTasks(results))
+
+			// Offer to show logged results
+			if (loggedResults.length) {
+				// Add a button with correctly pluralized text
+				$tasks.append('<a class="showMore">' +
+					((loggedResults.length === 1) ? $l._('showLoggedTask') : $l._('showLoggedTasks', [loggedResults.length])) +
+					'</a>');
+
+				// Show the logged results when the button is clicked
+				$tasks.find('.showMore').click(function () {
+					$tasks.find('ul').append(ui.lists.drawTasks(loggedResults));
+					$(this).hide();
+				});
+			}
 		}
 	})
 })

--- a/js/plugins/search.js
+++ b/js/plugins/search.js
@@ -62,6 +62,7 @@ plugin.add(function() {
 			// Set vars
 			var query = input.split(' '),
 				results = [],
+				loggedResults = [],
 				search;
 
 			if (ui.session.selected == 'all') {
@@ -74,7 +75,11 @@ plugin.add(function() {
 						// Search Task
 						var str = searcher(t)
 						if (str) {
-							results.push(str)
+							if (core.storage.tasks[t].list === 'logbook') {
+								loggedResults.push(str)
+							} else {
+								results.push(str)
+							}
 						}
 
 					}
@@ -89,6 +94,20 @@ plugin.add(function() {
 			}
 			// Draws
 			$tasks.find('ul').append(ui.lists.drawTasks(results))
+
+			// Offer to show logged results
+			if (loggedResults.length) {
+				// Add a button with correctly pluralized text
+				$tasks.append('<a class="showMore">' +
+					((loggedResults.length === 1) ? $l._('showLoggedTask') : $l._('showLoggedTasks', [loggedResults.length])) +
+					'</a>');
+
+				// Show the logged results when the button is clicked
+				$tasks.find('.showMore').click(function () {
+					$tasks.find('ul').append(ui.lists.drawTasks(loggedResults));
+					$(this).hide();
+				});
+			}
 		}
 	})
 })

--- a/js/translations/arabic.js
+++ b/js/translations/arabic.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magic",

--- a/js/translations/basque.js
+++ b/js/translations/basque.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magic",

--- a/js/translations/bulgarian.js
+++ b/js/translations/bulgarian.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Магия",

--- a/js/translations/chinese.js
+++ b/js/translations/chinese.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "添加列表",
 	moveToLogbookSingle: "移动 1 项已完成的任务至日志本",
 	moveToLogbookPlural: "移动 %s 项已完成的任务至日志本",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "智能",

--- a/js/translations/dutch.js
+++ b/js/translations/dutch.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Lijstje toevoegen",
 	moveToLogbookSingle: "1 voltooide taak naar het logboek verplaatsen",
 	moveToLogbookPlural: "%s voltooide taken naar het logboek verplaatsen",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magisch",

--- a/js/translations/english.js
+++ b/js/translations/english.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magic",

--- a/js/translations/finnish.js
+++ b/js/translations/finnish.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Taikuudella",

--- a/js/translations/french.js
+++ b/js/translations/french.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magique",

--- a/js/translations/german.js
+++ b/js/translations/german.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magisch",

--- a/js/translations/hungarian.js
+++ b/js/translations/hungarian.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magic",

--- a/js/translations/italian.js
+++ b/js/translations/italian.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magic",

--- a/js/translations/pirate.js
+++ b/js/translations/pirate.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magically",

--- a/js/translations/polish.js
+++ b/js/translations/polish.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magic",

--- a/js/translations/portuguese.js
+++ b/js/translations/portuguese.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magic",

--- a/js/translations/russian.js
+++ b/js/translations/russian.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magic",

--- a/js/translations/spanish.js
+++ b/js/translations/spanish.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Nuevo grupo",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Mágico",

--- a/js/translations/turkish.js
+++ b/js/translations/turkish.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magic",

--- a/js/translations/vietnamese.js
+++ b/js/translations/vietnamese.js
@@ -23,6 +23,8 @@ ui.language({
 	addList: "Add List",
 	moveToLogbookSingle: "Move 1 completed task to the Logbook",
 	moveToLogbookPlural: "Move %s completed tasks to the Logbook",
+	showLoggedTask: "Show 1 logged task",
+	showLoggedTasks: "Show %s logged tasks",
 
 	// Sort
 	sortMagic: "Magic",

--- a/sass/metro.scss
+++ b/sass/metro.scss
@@ -267,6 +267,7 @@ html, button, input, select, textarea {
         }
     }
     .tasksContent {
+        font-size: 15px;
         text-align: left;
 
         h2 {
@@ -381,7 +382,6 @@ html, button, input, select, textarea {
                     }
                 }
                 .content {
-                    font-size: 15px;
                     padding: 0 10px 0 0;
                 }
                 .notes {

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -447,9 +447,9 @@ html, button, input, select, textarea {
 	.shrink { background-size: contain; }
 
 	.tasksContent {
+		font-size: 13px;
 		overflow-y: auto;
 		text-align: center;
-		
 		
 		h2 {
 			text-align: center;
@@ -477,7 +477,7 @@ html, button, input, select, textarea {
 			margin: 0;
 			text-align: left;
 
-			&:last-child {
+			&:last-of-type {
 				padding-bottom: 20px;
 			}
 		
@@ -492,10 +492,9 @@ html, button, input, select, textarea {
 				z-index: 2;
 				margin-bottom: -1px;
 
-				background: #fff;				
+				background: #fff;
 				border: 1px solid #000;
-						
-				font-size: 13px;
+
 				line-height: 30px;
 				color: #111;
 				-webkit-transform: translateZ(0);
@@ -686,6 +685,13 @@ html, button, input, select, textarea {
 						}
 					}
 				}
+			}
+		}
+		.showMore {
+			color: #555;
+			margin-left: 16px;
+			&:hover {
+				text-decoration: underline;
 			}
 		}
 	}


### PR DESCRIPTION
When you search the "All Tasks" list (which happens when clicking a tag name), logged tasks are also shown in the results.  This change hides logged tasks by default, but adds a button to show them on demand.

I also fixed up some of the dictionaries so they all have the same keys, comments, etc. Then I added two new keys for the option to show logged tasks.

It looks like recompiling `styles.css` brought in some leftover changes that must not have been compiled the last time `styles.scss` was updated. They look like they're related to the sorting menu, so they might be from [Bumxu's pull request](https://github.com/stayradiated/Nitro/commit/6aa4640b880287ddf54d9761cf36bcabd7dc7b25) a couple days ago.
