### PR TITLE
Make it easier to deselect tasks when a background is set

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -878,7 +878,7 @@ $tasks.on('expand', 'li', function() {
 
 // Deselecting all tasks
 $('#tasks > .tasksContent').click(function(e) {
-	if(e.target.nodeName == 'UL' || e.target.nodeName == 'H2' || e.target.className == 'tasksContent') {
+	if(e.target.nodeName == 'UL' || e.target.nodeName == 'H2' || e.target.className.indexOf('tasksContent') > -1) {
 		$tasks.find('.expanded').dblclick()
 		$tasks.find('.selected').removeClass('selected')
 		ui.panel.updateButtons({del: false})


### PR DESCRIPTION
When a user sets a background, the `.tasksContent` div gets an additional class (`zoom`, `tile`, `shrink`). This means that the `e.target.className == 'tasksContent'` check in main.js fails, making it difficult to collapse tasks.  This fixes that by searching anywhere in `className` for `tasksContent`.
