### PR TITLE
Prevent a task's date from being set to NaN

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -865,7 +865,9 @@ $tasks.on('expand', 'li', function() {
 	$this.find('.date')
 		.datepicker({weekStart: core.storage.prefs.weekStartsOn})
 		.on('change', function() {
-			core.storage.tasks[id].date = Date.parse($(this).val())
+			// Use the new date, or an empty string if Date.parse doesn't understand the input
+			var newDate = Date.parse($(this).val()) || '';
+			core.storage.tasks[id].date = newDate
 			ui.lists.update().count()
 			core.storage.save([['tasks', id, 'date']])
 		})


### PR DESCRIPTION
If you manually enter a date and `Date.parse()` doesn't understand it, it returns `NaN`, which gets saved in the database. Then, when you next start Nitro, `NaN` dates get converted to `0` (maybe by the cleanDB plugin?), which is actually a valid date.  So tasks that should have no date at all actually show up in in the "Today" list.  This commit fixes that by falling back to an empty string if `Date.parse()` doesn't understand the input.
