### PR TITLE
"Tags..." and "Search results" translations

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -196,7 +196,7 @@ html, button, input, select, textarea { font-family: "Helvetica", "Arial", "Ubun
 #tasks .tasksContent ul li input.date { text-align: center; }
 #tasks .tasksContent ul li input.date, #tasks .tasksContent ul li input.tags { border-left: 1px solid #000; padding: 7px 5px; vertical-align: top; width: 80px; }
 #tasks .tasksContent ul li input.date:focus, #tasks .tasksContent ul li input.tags:focus { outline: 0; }
-#tasks .tasksContent ul li input.tags { -webkit-transition: width 0.15s; -moz-transition: width 0.15s; -o-transition: width 0.15s; transition: width 0.15s; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 59px; }
+#tasks .tasksContent ul li input.tags { -webkit-transition: width 0.15s; -moz-transition: width 0.15s; -o-transition: width 0.15s; transition: width 0.15s; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 96px; padding: 7px 9px; }
 #tasks .tasksContent ul li input.tags:focus, #tasks .tasksContent ul li input.tags.hasContent { width: 250px; }
 #tasks .tasksContent ul li.expanded { opacity: 1; }
 #tasks .tasksContent ul li.selected.expanded { background: #fff; }

--- a/js/main.js
+++ b/js/main.js
@@ -569,6 +569,7 @@ var ui = {
 				content: plugin.url(model.content).toText(),
 				notes: model.notes,
 				notesPlaceholder : $l._('notes'),
+				tagsPlaceholder : $l._("tags"),
 				datePlaceholder: $l._('dueDate'),
 				date: dateStr,
 				tags: model.tags.toString().replace(/,/g,', '),

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -1836,7 +1836,7 @@ plugin.add(function() {
 		} else {
 
 			// Puts the results into the UI
-			$tasks.html('<h2>Search Results: ' + $this.val() + '</h2><ul></ul>')
+			$tasks.html('<h2>'+$.i18n._('searchResults')+': ' + $this.val() + '</h2><ul></ul>')
 
 			// Set vars
 			var query = input.split(' '),

--- a/js/plugins/search.js
+++ b/js/plugins/search.js
@@ -27,7 +27,7 @@ plugin.add(function() {
 		} else {
 
 			// Puts the results into the UI
-			$tasks.html('<h2>Search Results: ' + $this.val() + '</h2><ul></ul>')
+			$tasks.html('<h2>'+$.i18n._('searchResults')+': ' + $this.val() + '</h2><ul></ul>')
 
 			// Set vars
 			var query = input.split(' '),

--- a/js/templates.js
+++ b/js/templates.js
@@ -16,7 +16,7 @@ templates = {
 			<div class="boxhelp">\
 				<div class="{{logged}}"></div>\
 				<input class="content" value="{{content}}" type="text">\
-				<input class="tags{{#tags}} hasContent{{/tags}}" value="{{tags}}" placeholder="Tags, seperated by a comma"><button class="priority {{priority}}">{{i18n_priority}}</button><input value="{{date}}" type="text" class="date" placeholder="{{datePlaceholder}}">\
+				<input class="tags{{#tags}} hasContent{{/tags}}" value="{{tags}}" placeholder="{{tagsPlaceholder}}"><button class="priority {{priority}}">{{i18n_priority}}</button><input value="{{date}}" type="text" class="date" placeholder="{{datePlaceholder}}">\
 			</div>\
 			<div class="hidden">\
 				<textarea placeholder="{{notesPlaceholder}}">{{notes}}</textarea>\

--- a/js/translations/arabic.js
+++ b/js/translations/arabic.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "No Tasks in %s",
 	thisList: "This List",
+	
+	// Search Result Header
+	searchResults: "البحث نتائج",
 
 	//Default Names
 	nlist: "قائمة جديدة",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "البحث",
 	notes: "ملاحظات",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "لا شيء",

--- a/js/translations/basque.js
+++ b/js/translations/basque.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "No Tasks in %s",
 	thisList: "This List",
+	
+	// Search Result Header
+	searchResults: "Bilaketaren emaitzak",
 
 	//Default Names
 	nlist: "Zerrenda berria",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Bilatu",
 	notes: "Notak",
+	tags: "Etiketak, komaz bereizita",
 
 	//Priority
 	none: "Lehentasunik ez",

--- a/js/translations/bulgarian.js
+++ b/js/translations/bulgarian.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "No Tasks in %s",
 	thisList: "This List",
+	
+	// Search Result Header
+	searchResults: "Search results",
 
 	//Default Names
 	nlist: "Нов списък",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Търси",
 	notes: "Записки",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "Няма",

--- a/js/translations/chinese.js
+++ b/js/translations/chinese.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "在 %s 无任务列表",
 	thisList: "该列表",
+	
+	// Search Result Header
+	searchResults: "Search results",
 
 	//Default Names
 	nlist: "新列表",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "搜索",
 	notes: "便笺",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "无",

--- a/js/translations/dutch.js
+++ b/js/translations/dutch.js
@@ -11,6 +11,8 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "Geen taken in %s",
 	thisList: "Dit lijstje",
+	// Search Result Header
+	searchResults: "Search results",
 
 	//Default Names
 	nlist: "Nieuw lijstje",
@@ -36,6 +38,7 @@ ui.language({
 	//Placeholder Text
 	search: "Zoeken",
 	notes: "Notities",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "Geen",

--- a/js/translations/english.js
+++ b/js/translations/english.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "No Tasks in %s",
 	thisList: "This List",
+	
+	// Search Result Header
+	searchResults: "Search results",
 
 	//Default Names
 	nlist: "New List",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Search",
 	notes: "Notes",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "None",

--- a/js/translations/finnish.js
+++ b/js/translations/finnish.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "Ei tehtäviä listassa %s",
 	thisList: "Tämä lista",
+	
+	// Search Result Header
+	searchResults: "Search results",
 
 	//Default Names
 	nlist: "Uusi lista",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Hae",
 	notes: "Huomautukset",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "Ei mitään",

--- a/js/translations/french.js
+++ b/js/translations/french.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "Aucune tâche dans %s",
 	thisList: "Cette liste-ci",
+	
+	// Search Result Header
+	searchResults: "Résultats de la recherche",
 
 	//Default Names
 	nlist: "Nouvelle liste",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Recherche",
 	notes: "Notes",
+	tags: "Balises, séparés par des virgules",
 
 	//Priority
 	none: "Aucune",

--- a/js/translations/german.js
+++ b/js/translations/german.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "No Tasks in %s",
 	thisList: "This List",
+	
+	// Search Result Header
+	searchResults: "Search results",
 
 	//Default Names
 	nlist: "Neue Liste",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Suchen",
 	notes: "Notizen",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "Keine",

--- a/js/translations/hungarian.js
+++ b/js/translations/hungarian.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "No Tasks in %s",
 	thisList: "This List",
+	
+	// Search Result Header
+	searchResults: "Search results",
 
 	//Default Names
 	nlist: "Új lista",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Keresés",
 	notes: "Megjegyzés",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "Nincs",

--- a/js/translations/italian.js
+++ b/js/translations/italian.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "No Tasks in %s",
 	thisList: "This List",
+	
+	// Search Result Header
+	searchResults: "Risultati della ricerca",
 
 	//Default Names
 	nlist: "Nuovo elenco",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Cerca",
 	notes: "Note",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "Nessuna priorità",

--- a/js/translations/pirate.js
+++ b/js/translations/pirate.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "No Tasks in %s",
 	thisList: "This List",
+	
+	// Search Result Header
+	searchResults: "Search resultz",
 
 	//Default Names
 	nlist: "Parchment",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Search",
 	notes: "Notes",
+	tags: "Tags, muzt separate with commas",
 
 	//Priority
 	none: "Empty",

--- a/js/translations/polish.js
+++ b/js/translations/polish.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "No Tasks in %s",
 	thisList: "This List",
+	
+	// Search Result Header
+	searchResults: "Search results",
 
 	//Default Names
 	nlist: "Nowa lista",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Szukaj",
 	notes: "Notatka",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "Brak",

--- a/js/translations/portuguese.js
+++ b/js/translations/portuguese.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "Nenhuma Tarefa em %s",
 	thisList: "Esta Lista",
+	
+	// Search Result Header
+	searchResults: "Search results",
 
 	//Default Names
 	nlist: "Nova Lista",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Buscar",
 	notes: "Notas",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "Prioridade",

--- a/js/translations/russian.js
+++ b/js/translations/russian.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "No Tasks in %s",
 	thisList: "This List",
+	
+	// Search Result Header
+	searchResults: "Search results",
 
 	//Default Names
 	nlist: "Новый Список",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Поиск",
 	notes: "Примечания",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "Важность",

--- a/js/translations/spanish.js
+++ b/js/translations/spanish.js
@@ -10,7 +10,10 @@ ui.language({
 
 	// Empty List Filler Text
 	noTasksInList: "Ninguna tarea en %s",
-	thisList: "Este Grupo",
+	thisList: "este grupo",
+	
+	// Search Result Header
+	searchResults: "Resultados de la búsqueda",
 
 	//Default Names
 	nlist: "Nuevo grupo",
@@ -35,7 +38,8 @@ ui.language({
 
 	//Placeholder Text
 	search: "Buscar",
-	notes: "Notas",
+	notes: "Detalles",
+	tags: "Etiquetas, separadas por coma",
 
 	//Priority
 	none: "No prioritario",
@@ -48,11 +52,11 @@ ui.language({
 	schedule: "Programar",
 
 	// Due Date Labels
-	daysOverdue: "%s days overdue",
-	dueYesterday: "due yesterday",
-	dueToday: "due today",
-	dueTomorrow: "due tomorrow",
-	daysLeft: "%s days left",
+	daysOverdue: "%s días tarde",
+	dueYesterday: "Ayer",
+	dueToday: "Debe ser hoy",
+	dueTomorrow: "Mañana",
+	daysLeft: "Faltan %s días",
 	
 	// Datepicker
 	weekStartsOn: "La semana comienza en: ",

--- a/js/translations/turkish.js
+++ b/js/translations/turkish.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "%s içinde görev yok",
 	thisList: "Bu liste",
+	
+	// Search Result Header
+	searchResults: "Search results",
 
 	//Default Names
 	nlist: "Yeni Liste",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search:"Ara", 
 	notes: "Not Ekle",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "Hiçbiri",

--- a/js/translations/vietnamese.js
+++ b/js/translations/vietnamese.js
@@ -11,6 +11,9 @@ ui.language({
 	// Empty List Filler Text
 	noTasksInList: "Không có việc gì trong %s",
 	thisList: "Danh sách này",
+	
+	// Search Result Header
+	searchResults: "Search results",
 
 	//Default Names
 	nlist: "Danh sách mới",
@@ -36,6 +39,7 @@ ui.language({
 	//Placeholder Text
 	search: "Tìm kiếm",
 	notes: "Ghi chú",
+	tags: "Tags, separated by a comma",
 
 	//Priority
 	none: "Không",

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -663,7 +663,8 @@ html, button, input, select, textarea {
 					overflow: hidden;
 					text-overflow: ellipsis;
 					white-space: nowrap;
-					width: 59px;
+					width: 96px;
+					padding: 7px 9px;
 					&:focus,
 					&.hasContent {
 						width: 250px;


### PR DESCRIPTION
Two things that could not be translated from the translation files:
- "Tags, separated by comma" placeholder in task box.
- "Search result:" after make a search.

`plugins.js` and `style.css` updated  :-p

Congratulations for 1.5, greetings.
