### PR TITLE
drag & drop to same list removes task from list

### DIFF
--- a/app/models/list.coffee
+++ b/app/models/list.coffee
@@ -51,6 +51,7 @@ class window.List extends Spine.Model
 
   # Move a task from one list to another
   moveTask: (task, newList) =>
+    if @id == newList.id then return
     task.updateAttribute "list", newList.id
     newList.addTask task
     @removeTask task, forceUpdate: yes


### PR DESCRIPTION
hey there,

currently if you drag whatever task and drop it on the same list, nothing seems to happen (as expected).  However if you re-render the task list (e.g. by clicking the list item again) the task isn't listed anymore.  The task actually is still valid (and you see it in the all tasks list), it's just removed from the (current/target) list.

This change adds a check comparing list ids on List.moveTask and simply returns if they are equal

cheers
  stesie
